### PR TITLE
feat: add SDK token authentication and custom base  URL support

### DIFF
--- a/src/client-factory.ts
+++ b/src/client-factory.ts
@@ -1,15 +1,27 @@
 export interface ClientOptions {
   apiKey?: string;
+  sdkToken?: string;
   bearerToken?: string;
+  baseUrl?: string;
 }
 
 export abstract class ClientFactory {
-  constructor(protected readonly options: ClientOptions) {
-    if (!options.apiKey && !options.bearerToken) {
-      throw new TypeError('One of the "apiKey" or "bearerToken" options must be specified');
+  constructor(
+    protected readonly options: ClientOptions,
+  ) {
+    const { apiKey, bearerToken, sdkToken } = options;
+    const tokenCount = [apiKey, bearerToken, sdkToken].filter(Boolean).length;
+
+    if (tokenCount === 0) {
+      throw new TypeError(
+        'One of the "apiKey", "bearerToken", or "sdkToken" options must be specified'
+      );
     }
-    if (options.apiKey && options.bearerToken) {
-      throw new TypeError('One and only one of the "apiKey" or "bearerToken" options must be specified');
+
+    if (tokenCount > 1) {
+      throw new TypeError(
+        'Only one of the "apiKey", "bearerToken", or "sdkToken" options must be specified'
+      );
     }
   }
 }

--- a/src/rest/client.ts
+++ b/src/rest/client.ts
@@ -7,6 +7,7 @@ export interface RestClientOptions {
   baseUrl: string;
   apiKey?: string;
   bearerToken?: string;
+  sdkToken?: string;
 }
 
 export abstract class RestClient {
@@ -18,6 +19,7 @@ export abstract class RestClient {
     const headers = Object.assign({},
       this.options.apiKey && { 'X-API-KEY': this.options.apiKey },
       this.options.bearerToken && { Authorization: `Bearer ${this.options.bearerToken}` },
+      this.options.sdkToken && { 'X-SDK-TOKEN': this.options.sdkToken },
     ) as Record<string, string>;
 
     return fetch(url, { headers }).then(res => res.json());

--- a/src/rest/factory.ts
+++ b/src/rest/factory.ts
@@ -20,7 +20,7 @@ export class RestClientFactory extends ClientFactory {
 
     if (!client) {
       const baseUrl = this.options.baseUrl || `${FUGLE_MARKETDATA_API_REST_BASE_URL}/${FUGLE_MARKETDATA_API_VERSION}`;
-      const url = `${baseUrl}/${type}`;
+      const url = `${baseUrl.replace(/\/+$/, '')}/${type}`;
 
       /* istanbul ignore else */
       if (type === 'stock') {

--- a/src/rest/factory.ts
+++ b/src/rest/factory.ts
@@ -19,13 +19,14 @@ export class RestClientFactory extends ClientFactory {
     let client = this.clients.get(type);
 
     if (!client) {
-      const baseUrl = `${FUGLE_MARKETDATA_API_REST_BASE_URL}/${FUGLE_MARKETDATA_API_VERSION}/${type}`;
+      const baseUrl = this.options.baseUrl || `${FUGLE_MARKETDATA_API_REST_BASE_URL}/${FUGLE_MARKETDATA_API_VERSION}`;
+      const url = `${baseUrl}/${type}`;
 
       /* istanbul ignore else */
       if (type === 'stock') {
-        client = new RestStockClient({ ...this.options, baseUrl });
+        client = new RestStockClient({ ...this.options, baseUrl: url });
       } else if (type === 'futopt') {
-        client = new RestFutOptClient({ ...this.options, baseUrl });
+        client = new RestFutOptClient({ ...this.options, baseUrl: url });
       } else {
         throw new TypeError('invalid client type');
       }

--- a/src/websocket/client.ts
+++ b/src/websocket/client.ts
@@ -6,6 +6,7 @@ export interface WebSocketClientOptions {
   url: string;
   apiKey?: string;
   bearerToken?: string;
+  sdkToken?: string;
 }
 
 export class WebSocketClient extends events.EventEmitter {
@@ -56,6 +57,9 @@ export class WebSocketClient extends events.EventEmitter {
     }
     if (this.options.bearerToken) {
       this.send({ event: 'auth', data: { token: this.options.bearerToken } });
+    }
+    if (this.options.sdkToken) {
+      this.send({ event: 'auth', data: { sdkToken: this.options.sdkToken } });
     }
   }
 

--- a/src/websocket/factory.ts
+++ b/src/websocket/factory.ts
@@ -20,7 +20,7 @@ export class WebSocketClientFactory extends ClientFactory {
 
     if (!client) {
       const baseUrl = this.options.baseUrl || `${FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL}/${FUGLE_MARKETDATA_API_VERSION}`;
-      const url = `${baseUrl}/${type}/streaming`;
+      const url = `${baseUrl.replace(/\/+$/, '')}/${type}/streaming`;
 
       /* istanbul ignore else */
       if (type === 'stock') {

--- a/src/websocket/factory.ts
+++ b/src/websocket/factory.ts
@@ -19,7 +19,8 @@ export class WebSocketClientFactory extends ClientFactory {
     let client = this.clients.get(type);
 
     if (!client) {
-      const url = `${FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL}/${FUGLE_MARKETDATA_API_VERSION}/${type}/streaming`;
+      const baseUrl = this.options.baseUrl || `${FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL}/${FUGLE_MARKETDATA_API_VERSION}`;
+      const url = `${baseUrl}/${type}/streaming`;
 
       /* istanbul ignore else */
       if (type === 'stock') {

--- a/test/rest-client.spec.ts
+++ b/test/rest-client.spec.ts
@@ -41,6 +41,11 @@ describe('RestClient', () => {
     it('should throw an error if all three tokens are specified', () => {
       expect(() => new RestClient({ apiKey: 'api-key', bearerToken: 'bearer-token', sdkToken: 'sdk-token' })).toThrowError();
     });
+
+    it('should create a RestClient instance with custom baseUrl', () => {
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com/v2.0' });
+      expect(client).toBeInstanceOf(RestClient);
+    });
   });
 
   describe('.stock', () => {
@@ -55,6 +60,22 @@ describe('RestClient', () => {
       const stock1 = client.stock;
       const stock2 = client.stock;
       expect(stock1).toBe(stock2);
+    });
+
+    it('should use custom baseUrl for stock client', () => {
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com/v2.0' });
+      const stock = client.stock;
+      expect(stock).toBeInstanceOf(RestStockClient);
+      // @ts-ignore - accessing private property for testing
+      expect(stock.options.baseUrl).toBe('https://custom-api.example.com/v2.0/stock');
+    });
+
+    it('should use custom baseUrl for futopt client', () => {
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com/v2.0' });
+      const futopt = client.futopt;
+      expect(futopt).toBeInstanceOf(RestFutOptClient);
+      // @ts-ignore - accessing private property for testing
+      expect(futopt.options.baseUrl).toBe('https://custom-api.example.com/v2.0/futopt');
     });
 
     describe('.intraday', () => {
@@ -98,6 +119,16 @@ describe('RestClient', () => {
           expect(fetch).toBeCalledWith(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/tickers?type=INDEX',
             { headers: { 'X-SDK-TOKEN': 'sdk-token' } },
+          );
+        });
+
+        it('should request with custom baseUrl', async () => {
+          const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com/v2.0' });
+          const stock = client.stock as RestStockClient;
+          await stock.intraday.tickers({ type: 'INDEX' });
+          expect(fetch).toBeCalledWith(
+            'https://custom-api.example.com/v2.0/stock/intraday/tickers?type=INDEX',
+            { headers: { 'X-API-KEY': 'api-key' } },
           );
         });
       });
@@ -716,5 +747,39 @@ describe('RestClient', () => {
       });
     });
 
+  });
+
+  describe('URL normalization', () => {
+    it('should handle baseUrl without trailing slash', () => {
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/v1' });
+      const stock = client.stock;
+      // @ts-ignore - accessing private property for testing
+      expect(stock.options.baseUrl).toBe('https://api.example.com/v1/stock');
+    });
+
+    it('should handle baseUrl with single trailing slash', () => {
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/v1/' });
+      const stock = client.stock;
+      // @ts-ignore - accessing private property for testing
+      expect(stock.options.baseUrl).toBe('https://api.example.com/v1/stock');
+    });
+
+    it('should handle baseUrl with multiple trailing slashes', () => {
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/v1///' });
+      const stock = client.stock;
+      // @ts-ignore - accessing private property for testing
+      expect(stock.options.baseUrl).toBe('https://api.example.com/v1/stock');
+    });
+
+    it('should handle baseUrl with complex path and trailing slash', () => {
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/api/v2/' });
+      const stock = client.stock;
+      // @ts-ignore - accessing private property for testing
+      expect(stock.options.baseUrl).toBe('https://api.example.com/api/v2/stock');
+      
+      const futopt = client.futopt;
+      // @ts-ignore - accessing private property for testing
+      expect(futopt.options.baseUrl).toBe('https://api.example.com/api/v2/futopt');
+    });
   });
 });

--- a/test/rest-client.spec.ts
+++ b/test/rest-client.spec.ts
@@ -17,12 +17,29 @@ describe('RestClient', () => {
       expect(client).toBeInstanceOf(RestClient);
     });
 
+    it('should create a RestClient instance with sdkToken option', () => {
+      const client = new RestClient({ sdkToken: 'sdk-token' });
+      expect(client).toBeInstanceOf(RestClient);
+    });
+
     it('should throw an error if no options are specified', () => {
       expect(() => new RestClient({})).toThrowError();
     });
 
     it('should throw an error if both apiKey and bearerToken are specified', () => {
       expect(() => new RestClient({ apiKey: 'api-key', bearerToken: 'bearer-token' })).toThrowError();
+    });
+
+    it('should throw an error if both apiKey and sdkToken are specified', () => {
+      expect(() => new RestClient({ apiKey: 'api-key', sdkToken: 'sdk-token' })).toThrowError();
+    });
+
+    it('should throw an error if both bearerToken and sdkToken are specified', () => {
+      expect(() => new RestClient({ bearerToken: 'bearer-token', sdkToken: 'sdk-token' })).toThrowError();
+    });
+
+    it('should throw an error if all three tokens are specified', () => {
+      expect(() => new RestClient({ apiKey: 'api-key', bearerToken: 'bearer-token', sdkToken: 'sdk-token' })).toThrowError();
     });
   });
 
@@ -73,6 +90,16 @@ describe('RestClient', () => {
             { headers: { 'Authorization': 'Bearer bearer-token' } },
           );
         });
+
+        it('should request with sdk token', async () => {
+          const client = new RestClient({ sdkToken: 'sdk-token' });
+          const stock = client.stock as RestStockClient;
+          await stock.intraday.tickers({ type: 'INDEX' });
+          expect(fetch).toBeCalledWith(
+            'https://api.fugle.tw/marketdata/v1.0/stock/intraday/tickers?type=INDEX',
+            { headers: { 'X-SDK-TOKEN': 'sdk-token' } },
+          );
+        });
       });
 
       describe('.ticker()', () => {
@@ -93,6 +120,16 @@ describe('RestClient', () => {
           expect(fetch).toBeCalledWith(
             'https://api.fugle.tw/marketdata/v1.0/stock/intraday/ticker/2330',
             { headers: { 'Authorization': 'Bearer bearer-token' } },
+          );
+        });
+
+        it('should request with sdk token', async () => {
+          const client = new RestClient({ sdkToken: 'sdk-token' });
+          const stock = client.stock as RestStockClient;
+          await stock.intraday.ticker({ symbol: '2330' });
+          expect(fetch).toBeCalledWith(
+            'https://api.fugle.tw/marketdata/v1.0/stock/intraday/ticker/2330',
+            { headers: { 'X-SDK-TOKEN': 'sdk-token' } },
           );
         });
       });

--- a/test/websocket-client.spec.ts
+++ b/test/websocket-client.spec.ts
@@ -23,12 +23,29 @@ describe('WebSocketClient', () => {
       expect(client).toBeInstanceOf(WebSocketClient);
     });
 
+    it('should create a WebSocketClient instance with sdkToken option', () => {
+      const client = new WebSocketClient({ sdkToken: 'sdk-token' });
+      expect(client).toBeInstanceOf(WebSocketClient);
+    });
+
     it('should throw an error if no options are specified', () => {
       expect(() => new WebSocketClient({})).toThrowError();
     });
 
     it('should throw an error if both apiKey and bearerToken are specified', () => {
       expect(() => new WebSocketClient({ apiKey: 'api-key', bearerToken: 'bearer-token' })).toThrowError();
+    });
+
+    it('should throw an error if both apiKey and sdkToken are specified', () => {
+      expect(() => new WebSocketClient({ apiKey: 'api-key', sdkToken: 'sdk-token' })).toThrowError();
+    });
+
+    it('should throw an error if both bearerToken and sdkToken are specified', () => {
+      expect(() => new WebSocketClient({ bearerToken: 'bearer-token', sdkToken: 'sdk-token' })).toThrowError();
+    });
+
+    it('should throw an error if all three tokens are specified', () => {
+      expect(() => new WebSocketClient({ apiKey: 'api-key', bearerToken: 'bearer-token', sdkToken: 'sdk-token' })).toThrowError();
     });
   });
 
@@ -112,6 +129,15 @@ describe('WebSocketClient', () => {
         await server.connected;
         await expect(server).toReceiveMessage(JSON.stringify({ event: 'auth', data: { token: 'bearer-token' } }));
         expect(server).toHaveReceivedMessages([JSON.stringify({ event: 'auth', data: { token: 'bearer-token' } })]);
+      });
+
+      it('should send authenticate event with sdkToken when connected', async () => {
+        const client = new WebSocketClient({ sdkToken: 'sdk-token' });
+        const stock = client.stock;
+        stock.connect();
+        await server.connected;
+        await expect(server).toReceiveMessage(JSON.stringify({ event: 'auth', data: { sdkToken: 'sdk-token' } }));
+        expect(server).toHaveReceivedMessages([JSON.stringify({ event: 'auth', data: { sdkToken: 'sdk-token' } })]);
       });
 
       it('should resolve the Promise when authenticated', async () => {


### PR DESCRIPTION
feat: add SDK token authentication and custom base URL support

  - Add sdkToken as a third authentication option alongside apiKey and bearerToken
  - Support custom base URLs for both REST and WebSocket clients
  - Refactor token validation to handle all three auth types exclusively
  - Add comprehensive test coverage for all authentication methods