### PR TITLE
refactor(etf): remove code query param from etf-holdings

### DIFF
--- a/src/rest/stock/ownership/etf-holdings.ts
+++ b/src/rest/stock/ownership/etf-holdings.ts
@@ -5,7 +5,6 @@ export interface RestStockOwnershipEtfHoldingsParams {
   from?: string;
   to?: string;
   sort?: 'asc' | 'desc';
-  code?: string;
 }
 
 export interface RestStockOwnershipEtfHoldingsComponent {

--- a/test/rest-client.spec.ts
+++ b/test/rest-client.spec.ts
@@ -340,9 +340,9 @@ describe('RestClient', () => {
         it('should request with query params', async () => {
           const client = new RestClient({ apiKey: 'api-key' });
           const stock = client.stock as RestStockClient;
-          await stock.ownership.etfHoldings({ symbol: '0050', from: '2026-05-01', to: '2026-05-21', sort: 'desc', code: '2330' });
+          await stock.ownership.etfHoldings({ symbol: '0050', from: '2026-05-01', to: '2026-05-21', sort: 'desc' });
           expect(fetch).toBeCalledWith(
-            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/etf-holdings/0050?code=2330&from=2026-05-01&sort=desc&to=2026-05-21',
+            'https://api.fugle.tw/marketdata/v1.0/stock/ownership/etf-holdings/0050?from=2026-05-01&sort=desc&to=2026-05-21',
             { headers: { 'X-API-KEY': 'api-key' } },
           );
         });


### PR DESCRIPTION
## 概要
對齊 server-side MR [!376](https://git.fugle.tw/fugle/workspace-devs/fugle-realtime/-/merge_requests/376)，移除 `GET /v1.0/stock/ownership/etf-holdings/:symbol` 的選填 `code` query param。

這是 #8（新增 ETF endpoint）的 follow-up。#8 已 merge 進 `release/v1.5.0` 但尚未 release，趁 release 前把 `code` 拿掉，使用者不會看到帶 `code` 的版本。

## 為什麼移除
Server MR !376 已移除該 param（命名不一致、功能雞肋、cache key 膨脹）。移除後仍是 **soft degrade**：server 未開 whitelist，舊呼叫帶 `?code=` 不會報錯，只是拿回未過濾的完整清單。需過濾單一成分股時，client 端一行 filter `components` 即可。

## 變更內容
- `src/rest/stock/ownership/etf-holdings.ts`：移除 params interface 的 `code?: string;`
- `test/rest-client.spec.ts`：測試移除 `code`，URL 斷言同步更新

## 測試
- `jest`：92 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)