### PR TITLE
fix(client)!: separate baseUrl from the API version

### DIFF
--- a/src/base-url.ts
+++ b/src/base-url.ts
@@ -1,0 +1,26 @@
+const VERSION_SEGMENT = /\/v\d+\.\d+$/;
+
+/**
+ * Join a caller-supplied `baseUrl` with the version the SDK resolved.
+ *
+ * `baseUrl` carries the host and path prefix and nothing else; the version
+ * segment is always appended here. A version written into `baseUrl` is
+ * rejected rather than swapped or appended on top of, because letting two
+ * options decide the same path segment is what forced the old precedence
+ * rules — and those rules meant anyone who only wanted to change host was
+ * made to manage the version by hand.
+ */
+export const withVersion = (baseUrl: string, version: string, hint = ''): string => {
+  const trimmed = baseUrl.replace(/\/+$/, '');
+  const existing = trimmed.match(VERSION_SEGMENT);
+
+  if (existing) {
+    throw new TypeError(
+      `baseUrl must not include a version segment (found '${existing[0]}'). ` +
+      `Pass the host and path prefix only: '${trimmed.slice(0, -existing[0].length)}'.` +
+      (hint ? ` ${hint}` : '')
+    );
+  }
+
+  return `${trimmed}/${version}`;
+};

--- a/src/rest/factory.ts
+++ b/src/rest/factory.ts
@@ -2,6 +2,7 @@ import { RestClient } from './client';
 import { RestStockClient } from './stock/client';
 import { RestFutOptClient } from './futopt/client';
 import { ClientFactory } from '../client-factory';
+import { withVersion } from '../base-url';
 import { FUGLE_MARKETDATA_API_REST_BASE_URL, FUGLE_MARKETDATA_API_VERSION } from '../constants';
 
 export class RestClientFactory extends ClientFactory {
@@ -19,8 +20,15 @@ export class RestClientFactory extends ClientFactory {
     let client = this.clients.get(type);
 
     if (!client) {
-      const baseUrl = this.options.baseUrl || `${FUGLE_MARKETDATA_API_REST_BASE_URL}/${FUGLE_MARKETDATA_API_VERSION}`;
-      const url = `${baseUrl.replace(/\/+$/, '')}/${type}`;
+      // Same rule as streaming: baseUrl is host and path prefix, the SDK owns
+      // the version segment. REST serves one version, so there's no option to
+      // choose it with — but a version written into baseUrl is still rejected
+      // rather than silently doubled.
+      const baseUrl = withVersion(
+        this.options.baseUrl || FUGLE_MARKETDATA_API_REST_BASE_URL,
+        FUGLE_MARKETDATA_API_VERSION,
+      );
+      const url = `${baseUrl}/${type}`;
 
       /* istanbul ignore else */
       if (type === 'stock') {

--- a/src/websocket/factory.ts
+++ b/src/websocket/factory.ts
@@ -1,9 +1,10 @@
 import { WebSocketClient } from './client';
 import { WebSocketStockClient } from './stock/client';
 import { WebSocketFutOptClient } from './futopt/client';
-import { WebSocketProduct, applyVersionToBaseUrl, resolveVersion } from './version';
+import { WebSocketProduct, VERSION_OPTION_HINT, resolveVersion } from './version';
 import { FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL } from '../constants';
 import { ClientFactory } from '../client-factory';
+import { withVersion } from '../base-url';
 
 export class WebSocketClientFactory extends ClientFactory {
   private readonly clients = new Map<string, WebSocketClient>();
@@ -17,21 +18,15 @@ export class WebSocketClientFactory extends ClientFactory {
   }
 
   /**
-   * A `baseUrl` is only re-versioned when `version` was explicitly supplied.
-   * Left alone otherwise, the version the caller wrote into their URL wins —
-   * which keeps custom and internal deployments (whose paths need not follow
-   * the public versioning at all) working exactly as before.
+   * `baseUrl` picks the host and path prefix; `version` picks the version.
+   * Nothing else: a custom endpoint is written the same way as the public one,
+   * and pointing at a different host never forces the caller to track versions
+   * by hand.
    */
   private resolveBaseUrl(type: WebSocketProduct) {
     const version = resolveVersion(type, this.options.version);
-
-    if (!this.options.baseUrl) {
-      return `${FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL}/${version}`;
-    }
-
-    return this.options.version !== undefined
-      ? applyVersionToBaseUrl(this.options.baseUrl, version)
-      : this.options.baseUrl;
+    const baseUrl = this.options.baseUrl || FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL;
+    return withVersion(baseUrl, version, VERSION_OPTION_HINT);
   }
 
   private getClient(type: WebSocketProduct) {

--- a/src/websocket/version.ts
+++ b/src/websocket/version.ts
@@ -6,20 +6,24 @@ export type WebSocketVersion = typeof FUGLE_MARKETDATA_WS_SUPPORTED_VERSIONS[Web
 
 /**
  * Per-product form. Each product is narrowed to the versions it actually
- * serves, so `{ stock: 'v1.1' }` is a compile-time error.
+ * serves, so `{ stock: 'v1.1' }` is a compile-time error. A product left out
+ * of the map — including the empty map — gets that product's latest.
  */
 export type WebSocketVersionMap = {
   [P in WebSocketProduct]?: typeof FUGLE_MARKETDATA_WS_SUPPORTED_VERSIONS[P][number];
 };
 
 /**
- * Either a single version applied to every product, or a per-product map.
+ * The `version` option: always a per-product map.
  *
- * The scalar form can't be checked at compile time — which product it ends up
- * applying to isn't known until a client is taken off the factory — so an
- * unsupported combination throws when that client is created.
+ * A bare version string used to be accepted as "this version for every
+ * product", but which product it applied to wasn't known until a client was
+ * taken off the factory, so an unsupported pairing only surfaced then — and
+ * with the products serving different version sets, the only scalar that never
+ * throws is the one every product happens to share. The map form says the same
+ * thing without the trap.
  */
-export type WebSocketVersionOption = WebSocketVersion | WebSocketVersionMap;
+export type WebSocketVersionOption = WebSocketVersionMap;
 
 const supportedVersions = (product: WebSocketProduct): readonly string[] =>
   FUGLE_MARKETDATA_WS_SUPPORTED_VERSIONS[product];
@@ -45,19 +49,23 @@ const assertSupported = (product: WebSocketProduct, version: string, hint: strin
 /**
  * Resolve the streaming version for a product from the `version` option.
  *
- * Omitted entirely, or omitted for this product in the map form, means the
- * product's latest. Nothing is ever silently clamped: asking for a version a
- * product doesn't serve throws rather than quietly handing back an older one.
+ * Omitted entirely, an empty map, or omitted for this product all mean the same
+ * thing: that product's latest. Nothing is ever silently clamped — asking for a
+ * version a product doesn't serve throws rather than quietly handing back an
+ * older one.
  */
 export const resolveVersion = (product: WebSocketProduct, version?: WebSocketVersionOption): string => {
   if (version === undefined) return latestVersion(product);
 
+  // Guard for JavaScript callers, who don't get the compile-time rejection.
   if (typeof version === 'string') {
     const alternatives = productsSupporting(version);
-    assertSupported(product, version, alternatives.length
-      ? `Use version: { ${alternatives[0]}: '${version}' } to target a single product.`
-      : `No product serves ${version}.`);
-    return version;
+    throw new TypeError(
+      `version must be a per-product map, not the bare string '${version}'. ` +
+      (alternatives.length
+        ? `Use version: { ${alternatives.map(p => `${p}: '${version}'`).join(', ')} }.`
+        : `No product serves ${version}.`)
+    );
   }
 
   const requested = version[product];
@@ -67,19 +75,6 @@ export const resolveVersion = (product: WebSocketProduct, version?: WebSocketVer
   return requested;
 };
 
-const VERSION_SEGMENT = /\/v\d+\.\d+$/;
-
-/**
- * Point an explicitly supplied `baseUrl` at `version` by swapping its trailing
- * version segment (`.../marketdata/v1.0` → `.../marketdata/v1.1`).
- *
- * A baseUrl without a recognizable version segment is left alone — it may be a
- * proxy or an internal deployment that doesn't encode a version in its path,
- * and inventing one would break it.
- */
-export const applyVersionToBaseUrl = (baseUrl: string, version: string): string => {
-  const trimmed = baseUrl.replace(/\/+$/, '');
-  return VERSION_SEGMENT.test(trimmed)
-    ? trimmed.replace(VERSION_SEGMENT, `/${version}`)
-    : trimmed;
-};
+/** Appended to `baseUrl` rejections, pointing at the option that owns the version. */
+export const VERSION_OPTION_HINT =
+  "The version comes from the `version` option, e.g. version: { futopt: 'v1.1' }.";

--- a/test/rest-client.spec.ts
+++ b/test/rest-client.spec.ts
@@ -43,7 +43,7 @@ describe('RestClient', () => {
     });
 
     it('should create a RestClient instance with custom baseUrl', () => {
-      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com/v2.0' });
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com' });
       expect(client).toBeInstanceOf(RestClient);
     });
   });
@@ -63,19 +63,19 @@ describe('RestClient', () => {
     });
 
     it('should use custom baseUrl for stock client', () => {
-      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com/v2.0' });
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com' });
       const stock = client.stock;
       expect(stock).toBeInstanceOf(RestStockClient);
       // @ts-ignore - accessing private property for testing
-      expect(stock.options.baseUrl).toBe('https://custom-api.example.com/v2.0/stock');
+      expect(stock.options.baseUrl).toBe('https://custom-api.example.com/v1.0/stock');
     });
 
     it('should use custom baseUrl for futopt client', () => {
-      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com/v2.0' });
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com' });
       const futopt = client.futopt;
       expect(futopt).toBeInstanceOf(RestFutOptClient);
       // @ts-ignore - accessing private property for testing
-      expect(futopt.options.baseUrl).toBe('https://custom-api.example.com/v2.0/futopt');
+      expect(futopt.options.baseUrl).toBe('https://custom-api.example.com/v1.0/futopt');
     });
 
     describe('.intraday', () => {
@@ -123,11 +123,11 @@ describe('RestClient', () => {
         });
 
         it('should request with custom baseUrl', async () => {
-          const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com/v2.0' });
+          const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com' });
           const stock = client.stock as RestStockClient;
           await stock.intraday.tickers({ type: 'INDEX' });
           expect(fetch).toBeCalledWith(
-            'https://custom-api.example.com/v2.0/stock/intraday/tickers?type=INDEX',
+            'https://custom-api.example.com/v1.0/stock/intraday/tickers?type=INDEX',
             { headers: { 'X-API-KEY': 'api-key' } },
           );
         });
@@ -929,35 +929,43 @@ describe('RestClient', () => {
 
   describe('URL normalization', () => {
     it('should handle baseUrl without trailing slash', () => {
-      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/v1' });
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/marketdata' });
       const stock = client.stock;
       // @ts-ignore - accessing private property for testing
-      expect(stock.options.baseUrl).toBe('https://api.example.com/v1/stock');
+      expect(stock.options.baseUrl).toBe('https://api.example.com/marketdata/v1.0/stock');
     });
 
     it('should handle baseUrl with single trailing slash', () => {
-      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/v1/' });
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/marketdata/' });
       const stock = client.stock;
       // @ts-ignore - accessing private property for testing
-      expect(stock.options.baseUrl).toBe('https://api.example.com/v1/stock');
+      expect(stock.options.baseUrl).toBe('https://api.example.com/marketdata/v1.0/stock');
     });
 
     it('should handle baseUrl with multiple trailing slashes', () => {
-      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/v1///' });
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/marketdata///' });
       const stock = client.stock;
       // @ts-ignore - accessing private property for testing
-      expect(stock.options.baseUrl).toBe('https://api.example.com/v1/stock');
+      expect(stock.options.baseUrl).toBe('https://api.example.com/marketdata/v1.0/stock');
     });
 
-    it('should handle baseUrl with complex path and trailing slash', () => {
+    it('should treat a path segment that is not a vX.Y version as part of the prefix', () => {
       const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/api/v2/' });
       const stock = client.stock;
       // @ts-ignore - accessing private property for testing
-      expect(stock.options.baseUrl).toBe('https://api.example.com/api/v2/stock');
-      
+      expect(stock.options.baseUrl).toBe('https://api.example.com/api/v2/v1.0/stock');
+
       const futopt = client.futopt;
       // @ts-ignore - accessing private property for testing
-      expect(futopt.options.baseUrl).toBe('https://api.example.com/api/v2/futopt');
+      expect(futopt.options.baseUrl).toBe('https://api.example.com/api/v2/v1.0/futopt');
+    });
+
+    it('should reject a baseUrl carrying its own version segment', () => {
+      const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.fugle.tw/marketdata/v1.0' });
+      expect(() => client.stock).toThrowError(
+        "baseUrl must not include a version segment (found '/v1.0'). " +
+        "Pass the host and path prefix only: 'https://api.fugle.tw/marketdata'."
+      );
     });
   });
 });

--- a/test/websocket-client.spec.ts
+++ b/test/websocket-client.spec.ts
@@ -54,7 +54,7 @@ describe('WebSocketClient', () => {
     });
 
     it('should create a WebSocketClient instance with custom baseUrl', () => {
-      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://custom-ws.example.com/v2.0' });
+      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://custom-ws.example.com' });
       expect(client).toBeInstanceOf(WebSocketClient);
     });
 
@@ -81,19 +81,19 @@ describe('WebSocketClient', () => {
     });
 
     it('should use custom baseUrl for stock client', () => {
-      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://custom-ws.example.com/v2.0' });
+      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://custom-ws.example.com' });
       const stock = client.stock;
       expect(stock).toBeInstanceOf(WebSocketStockClient);
       // @ts-ignore - accessing private property for testing
-      expect(stock.options.url).toBe('wss://custom-ws.example.com/v2.0/stock/streaming');
+      expect(stock.options.url).toBe('wss://custom-ws.example.com/v1.0/stock/streaming');
     });
 
     it('should use custom baseUrl for futopt client', () => {
-      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://custom-ws.example.com/v2.0' });
+      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://custom-ws.example.com' });
       const futopt = client.futopt;
       expect(futopt).toBeInstanceOf(WebSocketFutOptClient);
       // @ts-ignore - accessing private property for testing
-      expect(futopt.options.url).toBe('wss://custom-ws.example.com/v2.0/futopt/streaming');
+      expect(futopt.options.url).toBe('wss://custom-ws.example.com/v1.1/futopt/streaming');
     });
 
     describe('.connect()', () => {
@@ -467,35 +467,35 @@ describe('WebSocketClient', () => {
 
   describe('URL normalization', () => {
     it('should handle baseUrl without trailing slash', () => {
-      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://ws.example.com/v1' });
+      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://ws.example.com/marketdata' });
       const stock = client.stock;
       // @ts-ignore - accessing private property for testing
-      expect(stock.options.url).toBe('wss://ws.example.com/v1/stock/streaming');
+      expect(stock.options.url).toBe('wss://ws.example.com/marketdata/v1.0/stock/streaming');
     });
 
     it('should handle baseUrl with single trailing slash', () => {
-      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://ws.example.com/v1/' });
+      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://ws.example.com/marketdata/' });
       const stock = client.stock;
       // @ts-ignore - accessing private property for testing
-      expect(stock.options.url).toBe('wss://ws.example.com/v1/stock/streaming');
+      expect(stock.options.url).toBe('wss://ws.example.com/marketdata/v1.0/stock/streaming');
     });
 
     it('should handle baseUrl with multiple trailing slashes', () => {
-      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://ws.example.com/v1///' });
+      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://ws.example.com/marketdata///' });
       const stock = client.stock;
       // @ts-ignore - accessing private property for testing
-      expect(stock.options.url).toBe('wss://ws.example.com/v1/stock/streaming');
+      expect(stock.options.url).toBe('wss://ws.example.com/marketdata/v1.0/stock/streaming');
     });
 
-    it('should handle baseUrl with complex path and trailing slash', () => {
+    it('should treat a path segment that is not a vX.Y version as part of the prefix', () => {
       const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://ws.example.com/api/v2/' });
       const stock = client.stock;
       // @ts-ignore - accessing private property for testing
-      expect(stock.options.url).toBe('wss://ws.example.com/api/v2/stock/streaming');
+      expect(stock.options.url).toBe('wss://ws.example.com/api/v2/v1.0/stock/streaming');
 
       const futopt = client.futopt;
       // @ts-ignore - accessing private property for testing
-      expect(futopt.options.url).toBe('wss://ws.example.com/api/v2/futopt/streaming');
+      expect(futopt.options.url).toBe('wss://ws.example.com/api/v2/v1.1/futopt/streaming');
     });
   });
 
@@ -509,21 +509,25 @@ describe('WebSocketClient', () => {
       expect(urlOf(client, 'stock')).toBe(`${FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL}/v1.0/stock/streaming`);
     });
 
-    it('should apply a scalar version to futopt', () => {
-      const client = new WebSocketClient({ apiKey: 'api-key', version: 'v1.1' });
+    it('should treat an empty map the same as no version at all', () => {
+      const client = new WebSocketClient({ apiKey: 'api-key', version: {} });
       expect(urlOf(client, 'futopt')).toBe(`${FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL}/v1.1/futopt/streaming`);
-    });
-
-    it('should apply a scalar version to every product when all support it', () => {
-      const client = new WebSocketClient({ apiKey: 'api-key', version: 'v1.0' });
-      expect(urlOf(client, 'futopt')).toBe(`${FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL}/v1.0/futopt/streaming`);
       expect(urlOf(client, 'stock')).toBe(`${FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL}/v1.0/stock/streaming`);
     });
 
-    it('should throw for a product that does not serve the scalar version', () => {
+    it('should reject a bare version string at compile time', () => {
+      // @ts-expect-error - version is a per-product map, not a scalar
       const client = new WebSocketClient({ apiKey: 'api-key', version: 'v1.1' });
+      expect(() => client.futopt).toThrowError(
+        "version must be a per-product map, not the bare string 'v1.1'. Use version: { futopt: 'v1.1' }."
+      );
+    });
+
+    it('should name every product that serves a rejected bare version string', () => {
+      // @ts-expect-error - version is a per-product map, not a scalar
+      const client = new WebSocketClient({ apiKey: 'api-key', version: 'v1.0' });
       expect(() => client.stock).toThrowError(
-        "stock streaming does not support v1.1 (supported: v1.0). Use version: { futopt: 'v1.1' } to target a single product."
+        "version must be a per-product map, not the bare string 'v1.0'. Use version: { stock: 'v1.0', futopt: 'v1.0' }."
       );
     });
 
@@ -544,37 +548,34 @@ describe('WebSocketClient', () => {
       expect(() => client.stock).toThrowError('stock streaming does not support v1.1');
     });
 
-    it('should leave a custom baseUrl alone when no version is given', () => {
-      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://custom-ws.example.com/v2.0' });
-      expect(urlOf(client, 'futopt')).toBe('wss://custom-ws.example.com/v2.0/futopt/streaming');
+    it('should version a custom baseUrl per product, with no version option', () => {
+      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://fubon-api.fugle.tw/marketdata' });
+      expect(urlOf(client, 'futopt')).toBe('wss://fubon-api.fugle.tw/marketdata/v1.1/futopt/streaming');
+      expect(urlOf(client, 'stock')).toBe('wss://fubon-api.fugle.tw/marketdata/v1.0/stock/streaming');
     });
 
-    it('should swap the version segment of a custom baseUrl when a version is given', () => {
+    it('should apply the version option to a custom baseUrl', () => {
       const client = new WebSocketClient({
         apiKey: 'api-key',
-        baseUrl: 'wss://api-dev.fugle.tw/marketdata/v1.0',
-        version: { futopt: 'v1.1' },
+        baseUrl: 'wss://api-dev.fugle.tw/marketdata',
+        version: { futopt: 'v1.0' },
       });
-      expect(urlOf(client, 'futopt')).toBe('wss://api-dev.fugle.tw/marketdata/v1.1/futopt/streaming');
+      expect(urlOf(client, 'futopt')).toBe('wss://api-dev.fugle.tw/marketdata/v1.0/futopt/streaming');
       expect(urlOf(client, 'stock')).toBe('wss://api-dev.fugle.tw/marketdata/v1.0/stock/streaming');
     });
 
-    it('should swap the version segment of a custom baseUrl with trailing slashes', () => {
-      const client = new WebSocketClient({
-        apiKey: 'api-key',
-        baseUrl: 'wss://api-dev.fugle.tw/marketdata/v1.0//',
-        version: { futopt: 'v1.1' },
-      });
-      expect(urlOf(client, 'futopt')).toBe('wss://api-dev.fugle.tw/marketdata/v1.1/futopt/streaming');
+    it('should reject a baseUrl carrying its own version segment', () => {
+      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://api-dev.fugle.tw/marketdata/v1.0' });
+      expect(() => client.futopt).toThrowError(
+        "baseUrl must not include a version segment (found '/v1.0'). " +
+        "Pass the host and path prefix only: 'wss://api-dev.fugle.tw/marketdata'. " +
+        "The version comes from the `version` option, e.g. version: { futopt: 'v1.1' }."
+      );
     });
 
-    it('should leave a custom baseUrl without a version segment untouched', () => {
-      const client = new WebSocketClient({
-        apiKey: 'api-key',
-        baseUrl: 'wss://ws.example.com/api',
-        version: { futopt: 'v1.1' },
-      });
-      expect(urlOf(client, 'futopt')).toBe('wss://ws.example.com/api/futopt/streaming');
+    it('should reject a versioned baseUrl after trailing slashes are trimmed', () => {
+      const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://api-dev.fugle.tw/marketdata/v1.0//' });
+      expect(() => client.futopt).toThrowError("baseUrl must not include a version segment (found '/v1.0')");
     });
   });
 


### PR DESCRIPTION
## 問題根源：`baseUrl` 同時承載 host 和 version

`baseUrl` 這個字串混了兩個語意：換 host（富邦專屬 endpoint、內部部署、proxy）跟選版本。結果是任何只想換 host 的人，都被迫連 version 一起自己管——這正是我們寫死 `/v1.0` 的原因，不是因為想 pin，而是因為沒有別的方式表達「我只是換 host」。

順著同一條規則，還有三個 RC 階段該修掉的陷阱：

1. **`version: undefined` 與 `version: {}` 行為不同。** 前者保留 URL 裡的版本，後者 per-product resolve 到 latest。同樣是「我沒指定任何產品的版本」，結果不一樣。
2. **`applyVersionToBaseUrl` 對沒有版本段的 URL 是「留著不動」。** 所以就算傳乾淨的 `wss://fubon-api.fugle.tw/marketdata`，version 選項會被完全忽略——binding 單方面改根本改不動。
3. **scalar 形式 `version: 'v1.1'` 實質不可用。** 只要取到 `stock` 就必然 throw，而且是 lazy 的、延到取 client 才爆。它只在「這個 factory 我只拿 futopt」時才安全，等於一個看起來通用、實際只在特例成立的 API 形狀。

## 改法：同一個 URL 片段只能有一個 owner

`baseUrl` 只決定 host / path prefix，版本永遠由 `version` 決定並由 SDK 接上去。SDK 不再 parse `baseUrl`。

這也是主流 SDK 的分法：Stripe 的 `api_base` 是純 host、版本走 `Stripe-Version`；Anthropic、GitHub 同樣。版本放 path 的（Twilio 的 `/2010-04-01`）也是由 SDK 自己組，使用者永遠不寫那一段。

有個證據說明這本來就是原設計的意圖：`FUGLE_MARKETDATA_API_WEBSOCKET_BASE_URL` 常數本身就是乾淨的 `wss://api.fugle.tw/marketdata`，預設路徑做的正是 `${BASE}/${version}`。偏掉的只有「使用者自己傳 baseUrl」那條分支——這個 PR 讓兩條分支變成同一條。

### 具體變更

**新增 `src/base-url.ts`** — `withVersion(baseUrl, version, hint?)`，REST / WS 共用：trim 尾端斜線 → 尾端是 `/vX.Y` 就 throw → 否則 `baseUrl + '/' + version`。沒有 swap、沒有分支。

**`websocket/factory.ts`** — `resolveBaseUrl` 從兩條路收斂成三行，一律 `resolveVersion(product, version)` 再串接。

**`rest/factory.ts`** — 同一條規則，用它唯一服務的版本。REST 沒有 `version` 選項，但 baseUrl 帶版本段一樣 throw。

**`websocket/version.ts`** — 移除 scalar 形式，`WebSocketVersionOption` 現在是 `WebSocketVersionMap` 的 alias（`version: 'v1.1'` 變 compile error `TS2559`）；JS 端另有 runtime 擋，訊息會列出所有服務該版本的產品。`{}` 與 `undefined` 收斂成同一條路徑。

### 為什麼是 throw 而不是 swap

「尾端有版本段就換掉」看起來相容比較好，但那會**默默改掉使用者指定的 endpoint**——`baseUrl: '.../marketdata/v2.0'` 會被換成 `/v1.1`。純串接則會產生 `.../v2.0/v1.1/...` 這種難以理解的連線失敗。throw 是唯一會明講「你把值放錯旋鈕了」的選項，訊息直接給出該用的 prefix：

```
baseUrl must not include a version segment (found '/v1.0').
Pass the host and path prefix only: 'wss://api-dev.fugle.tw/marketdata'.
The version comes from the `version` option, e.g. version: { futopt: 'v1.1' }.
```

`version` 選項是 rc.3（兩週前）才進來的，所以「baseUrl + version 同時給」實質沒有使用者；真正的相容面是舊有「baseUrl 自帶 `/v1.0`」的寫法，那些人會拿到上面這則訊息。

## 結果

富邦 binding 完全照 official 規則，零特例：

```ts
new WebSocketClient({ apiKey, baseUrl: 'wss://fubon-api.fugle.tw/marketdata' })
// futopt → wss://fubon-api.fugle.tw/marketdata/v1.1/futopt/streaming
// stock  → wss://fubon-api.fugle.tw/marketdata/v1.0/stock/streaming

new RestClient({ apiKey, baseUrl: 'https://fubon-api.fugle.tw/marketdata' })
// stock  → https://fubon-api.fugle.tw/marketdata/v1.0/stock
```

## Breaking changes

- `baseUrl` 尾端帶 `/vX.Y` 會 throw `TypeError`。改成只傳 host + path prefix。
- scalar `version: 'v1.1'` 移除，改用 per-product map `version: { futopt: 'v1.1' }`。

⚠️ commit 帶了 `BREAKING CHANGE:` footer，release-it 的 angular preset 會據此推 major bump。若希望留在 1.5 RC 線上，release 時要明確指定版號。

## 測試

167 passed（既有測試全綠）。凡是「baseUrl 自帶版本段」的期望值都改成乾淨 baseUrl + 新預期輸出；`URL normalization` 那組保留 trailing-slash 的原意、prefix 換成 `/marketdata`，另外把 `/api/v2` 那個 case 改名為 `should treat a path segment that is not a vX.Y version as part of the prefix`，明確釘住 lint 邊界（`/api/v2` 不算版本段，會原樣留在 prefix）。新增涵蓋 `{}` 等同未指定、scalar 被拒、baseUrl 帶版本段被拒的測試。

未追蹤的 dev harness `test_futopt.ts` 也已在本機同步更新（它不在版控裡，不含在這個 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGBMNGKfgHPyNGMkHMcaJH
