### PR TITLE
feat(client): expose the resolved endpoint on rest and websocket clients

### DIFF
--- a/src/rest/client.ts
+++ b/src/rest/client.ts
@@ -13,6 +13,17 @@ export interface RestClientOptions {
 export abstract class RestClient {
   constructor(protected readonly options: RestClientOptions) {}
 
+  /**
+   * The prefix every request from this client is built on, fully resolved —
+   * host, version segment and product. Endpoints are appended to it.
+   *
+   * The version segment is chosen by the SDK rather than written by the
+   * caller, so this is the only way to see what a client actually resolved to.
+   */
+  public get baseUrl(): string {
+    return this.options.baseUrl;
+  }
+
   protected request = async (endpoint: string, params?: Record<string, any>) => {
     const url = queryString.stringifyUrl({ url: `${this.options.baseUrl}/${endpoint}`, query: params });
 

--- a/src/websocket/client.ts
+++ b/src/websocket/client.ts
@@ -32,6 +32,18 @@ export class WebSocketClient extends events.EventEmitter {
     super();
   }
 
+  /**
+   * The endpoint this client connects to, fully resolved — host, version
+   * segment, product and `/streaming`.
+   *
+   * The version segment is chosen by the SDK from the `version` option rather
+   * than written by the caller, so this is the only way to see which version a
+   * client actually ended up on.
+   */
+  public get url(): string {
+    return this.options.url;
+  }
+
   public connect() {
     this.socket = new WebSocket(this.options.url);
     this.socket.onopen = () => this.emit(CONNECT_EVENT);

--- a/test/rest-client.spec.ts
+++ b/test/rest-client.spec.ts
@@ -66,16 +66,14 @@ describe('RestClient', () => {
       const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com' });
       const stock = client.stock;
       expect(stock).toBeInstanceOf(RestStockClient);
-      // @ts-ignore - accessing private property for testing
-      expect(stock.options.baseUrl).toBe('https://custom-api.example.com/v1.0/stock');
+      expect(stock.baseUrl).toBe('https://custom-api.example.com/v1.0/stock');
     });
 
     it('should use custom baseUrl for futopt client', () => {
       const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://custom-api.example.com' });
       const futopt = client.futopt;
       expect(futopt).toBeInstanceOf(RestFutOptClient);
-      // @ts-ignore - accessing private property for testing
-      expect(futopt.options.baseUrl).toBe('https://custom-api.example.com/v1.0/futopt');
+      expect(futopt.baseUrl).toBe('https://custom-api.example.com/v1.0/futopt');
     });
 
     describe('.intraday', () => {
@@ -931,33 +929,28 @@ describe('RestClient', () => {
     it('should handle baseUrl without trailing slash', () => {
       const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/marketdata' });
       const stock = client.stock;
-      // @ts-ignore - accessing private property for testing
-      expect(stock.options.baseUrl).toBe('https://api.example.com/marketdata/v1.0/stock');
+      expect(stock.baseUrl).toBe('https://api.example.com/marketdata/v1.0/stock');
     });
 
     it('should handle baseUrl with single trailing slash', () => {
       const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/marketdata/' });
       const stock = client.stock;
-      // @ts-ignore - accessing private property for testing
-      expect(stock.options.baseUrl).toBe('https://api.example.com/marketdata/v1.0/stock');
+      expect(stock.baseUrl).toBe('https://api.example.com/marketdata/v1.0/stock');
     });
 
     it('should handle baseUrl with multiple trailing slashes', () => {
       const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/marketdata///' });
       const stock = client.stock;
-      // @ts-ignore - accessing private property for testing
-      expect(stock.options.baseUrl).toBe('https://api.example.com/marketdata/v1.0/stock');
+      expect(stock.baseUrl).toBe('https://api.example.com/marketdata/v1.0/stock');
     });
 
     it('should treat a path segment that is not a vX.Y version as part of the prefix', () => {
       const client = new RestClient({ apiKey: 'api-key', baseUrl: 'https://api.example.com/api/v2/' });
       const stock = client.stock;
-      // @ts-ignore - accessing private property for testing
-      expect(stock.options.baseUrl).toBe('https://api.example.com/api/v2/v1.0/stock');
+      expect(stock.baseUrl).toBe('https://api.example.com/api/v2/v1.0/stock');
 
       const futopt = client.futopt;
-      // @ts-ignore - accessing private property for testing
-      expect(futopt.options.baseUrl).toBe('https://api.example.com/api/v2/v1.0/futopt');
+      expect(futopt.baseUrl).toBe('https://api.example.com/api/v2/v1.0/futopt');
     });
 
     it('should reject a baseUrl carrying its own version segment', () => {

--- a/test/websocket-client.spec.ts
+++ b/test/websocket-client.spec.ts
@@ -84,16 +84,14 @@ describe('WebSocketClient', () => {
       const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://custom-ws.example.com' });
       const stock = client.stock;
       expect(stock).toBeInstanceOf(WebSocketStockClient);
-      // @ts-ignore - accessing private property for testing
-      expect(stock.options.url).toBe('wss://custom-ws.example.com/v1.0/stock/streaming');
+      expect(stock.url).toBe('wss://custom-ws.example.com/v1.0/stock/streaming');
     });
 
     it('should use custom baseUrl for futopt client', () => {
       const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://custom-ws.example.com' });
       const futopt = client.futopt;
       expect(futopt).toBeInstanceOf(WebSocketFutOptClient);
-      // @ts-ignore - accessing private property for testing
-      expect(futopt.options.url).toBe('wss://custom-ws.example.com/v1.1/futopt/streaming');
+      expect(futopt.url).toBe('wss://custom-ws.example.com/v1.1/futopt/streaming');
     });
 
     describe('.connect()', () => {
@@ -469,39 +467,33 @@ describe('WebSocketClient', () => {
     it('should handle baseUrl without trailing slash', () => {
       const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://ws.example.com/marketdata' });
       const stock = client.stock;
-      // @ts-ignore - accessing private property for testing
-      expect(stock.options.url).toBe('wss://ws.example.com/marketdata/v1.0/stock/streaming');
+      expect(stock.url).toBe('wss://ws.example.com/marketdata/v1.0/stock/streaming');
     });
 
     it('should handle baseUrl with single trailing slash', () => {
       const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://ws.example.com/marketdata/' });
       const stock = client.stock;
-      // @ts-ignore - accessing private property for testing
-      expect(stock.options.url).toBe('wss://ws.example.com/marketdata/v1.0/stock/streaming');
+      expect(stock.url).toBe('wss://ws.example.com/marketdata/v1.0/stock/streaming');
     });
 
     it('should handle baseUrl with multiple trailing slashes', () => {
       const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://ws.example.com/marketdata///' });
       const stock = client.stock;
-      // @ts-ignore - accessing private property for testing
-      expect(stock.options.url).toBe('wss://ws.example.com/marketdata/v1.0/stock/streaming');
+      expect(stock.url).toBe('wss://ws.example.com/marketdata/v1.0/stock/streaming');
     });
 
     it('should treat a path segment that is not a vX.Y version as part of the prefix', () => {
       const client = new WebSocketClient({ apiKey: 'api-key', baseUrl: 'wss://ws.example.com/api/v2/' });
       const stock = client.stock;
-      // @ts-ignore - accessing private property for testing
-      expect(stock.options.url).toBe('wss://ws.example.com/api/v2/v1.0/stock/streaming');
+      expect(stock.url).toBe('wss://ws.example.com/api/v2/v1.0/stock/streaming');
 
       const futopt = client.futopt;
-      // @ts-ignore - accessing private property for testing
-      expect(futopt.options.url).toBe('wss://ws.example.com/api/v2/v1.1/futopt/streaming');
+      expect(futopt.url).toBe('wss://ws.example.com/api/v2/v1.1/futopt/streaming');
     });
   });
 
   describe('streaming version', () => {
-    // @ts-ignore - accessing private property for testing
-    const urlOf = (client: WebSocketClient, product: 'stock' | 'futopt') => client[product].options.url;
+    const urlOf = (client: WebSocketClient, product: 'stock' | 'futopt') => client[product].url;
 
     it('should default each product to its latest version', () => {
       const client = new WebSocketClient({ apiKey: 'api-key' });


### PR DESCRIPTION
## 為什麼需要這個

rc4 把 `baseUrl` 收斂成「只決定 host / path prefix」之後，版本段改由 SDK 決定。這是對的分工，但它**拿走了使用者原本自然擁有的資訊**——以前版本是他自己寫進 URL 的，現在他問不出「我實際上跑在哪個版本」。

而且完全沒有出口：`RestClient` 和 `WebSocketClient` 的建構子都是 `protected readonly options`，連我們自己的測試都得靠 `@ts-ignore` 才讀得到：

```ts
// @ts-ignore - accessing private property for testing
stock.options.url
```

當測試需要繞過型別系統才能驗證行為，那通常表示缺的是公開 API，不是測試寫法有問題。

## 加了什麼

| | 回傳 |
|---|---|
| `WebSocketClient.url` | 完整 endpoint，含版本段與 `/streaming` |
| `RestClient.baseUrl` | 請求組裝的 prefix，含版本段與 product |

```ts
const client = new WebSocketClient({ apiKey, baseUrl: 'wss://fubon-api.fugle.tw/marketdata' });
client.futopt.url  // wss://fubon-api.fugle.tw/marketdata/v1.1/futopt/streaming
client.stock.url   // wss://fubon-api.fugle.tw/marketdata/v1.0/stock/streaming

new RestClient({ apiKey }).stock.baseUrl
// https://api.fugle.tw/marketdata/v1.0/stock
```

兩個都是唯讀、連線前就讀得到（取 `.futopt` 只建物件不連線），而且由 stock / futopt 子類別直接繼承——兩邊都只需要在基底類別加一個 getter。

## 設計取捨

**放 client 不放 factory。** 「連到哪」是 client 的性質，而 client 本來就是持有 socket 的東西。放 factory 會變成 `client.urlFor('futopt')`，但 product 在你拿到 `client.futopt` 的當下就確定了，再傳一次是多餘的。

**WS 叫 `url`，REST 叫 `baseUrl`。** REST 那個真的是 base——endpoint 會往後接；WS 那個是完整位址，叫 base 會誤導。

**只給 URL，不給 `version`。** 討論過是否要另外開 `client.futopt.version === 'v1.1'`。完整 URL 在 debug 時資訊更足（版本、host、product path 一次到位），而單獨的 `version` 需求目前還沒有人提。真的要加，也是後續三行的事。

## 測試

167 passed。既有的 URL 斷言全部改讀公開 accessor，`@ts-ignore` 從約 20 處降到 2 處——剩下那兩處是讀 private method 和 socket，跟這件事無關。

沒有另外加「accessor 專用」的測試：那些斷言會跟已經改寫過的既有測試一字不差地重複，而既有測試現在本來就是透過 accessor 驗證的——accessor 壞了它們會先紅。

## 相關

延續 #11（`baseUrl` 與版本分離）。這個 PR 補的是那次改動留下的可見性缺口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGBMNGKfgHPyNGMkHMcaJH
